### PR TITLE
Skip invalid race sessions

### DIFF
--- a/f1_predictor/dataset_builder.py
+++ b/f1_predictor/dataset_builder.py
@@ -64,9 +64,19 @@ def build_dataset(seasons: Iterable[int]) -> pd.DataFrame:
                 LOGGER.info("Skipping %s round %s (already processed)", year, rnd)
                 continue
             LOGGER.info("Processing %s round %s", year, rnd)
+            skip_race = False
             while True:
                 try:
                     session = loader.fetch_session(year, rnd, "R")
+                    break
+                except ValueError:
+                    LOGGER.exception(
+                        "Failed to fetch session %s round %s due to invalid data",
+                        year,
+                        rnd,
+                    )
+                    time.sleep(1)
+                    skip_race = True
                     break
                 except Exception:
                     LOGGER.exception(
@@ -75,6 +85,8 @@ def build_dataset(seasons: Iterable[int]) -> pd.DataFrame:
                         rnd,
                     )
                     time.sleep(5)
+            if skip_race:
+                continue
             results = getattr(session, "results", pd.DataFrame()).copy()
             if results.empty:
                 continue


### PR DESCRIPTION
## Summary
- handle `ValueError` when downloading a race session

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*