### PR TITLE
Add weather data features

### DIFF
--- a/f1_predictor/dataset_builder.py
+++ b/f1_predictor/dataset_builder.py
@@ -82,6 +82,9 @@ def build_dataset(seasons: Iterable[int]) -> pd.DataFrame:
             results["round"] = rnd
             rating = loader.fetch_racefans_rating(year, rnd)
             results["racefans_rating"] = rating
+            weather = loader.extract_weather(session)
+            results["air_temp"] = weather.get("air_temp")
+            results["humidity"] = weather.get("humidity")
             frames.append(results)
             processed_races.add((year, rnd))
 

--- a/f1_predictor/feature_engineering.py
+++ b/f1_predictor/feature_engineering.py
@@ -77,6 +77,10 @@ def generate_feature_matrix(df_raw: pd.DataFrame) -> Tuple[pd.DataFrame, pd.Seri
         numeric_features.append("fastest_lap_time")
     if "fastest_lap_speed" in df.columns:
         numeric_features.append("fastest_lap_speed")
+    if "air_temp" in df.columns:
+        numeric_features.append("air_temp")
+    if "humidity" in df.columns:
+        numeric_features.append("humidity")
 
     df["points_cumsum"] = (
         df.groupby("driver_id")["Points"].cumsum().shift(1)

--- a/f1_predictor/predict_next_race.py
+++ b/f1_predictor/predict_next_race.py
@@ -77,7 +77,15 @@ def _prepare_prediction_dataframe(df_hist: pd.DataFrame, year: int, rnd: int) ->
     latest = df_hist.groupby("driver_id").tail(1).reset_index(drop=True)
     latest["year"] = year
     latest["round"] = rnd
-    for col in ["Position", "GridPosition", "FastestLapTime", "FastestLapSpeed", "racefans_rating"]:
+    for col in [
+        "Position",
+        "GridPosition",
+        "FastestLapTime",
+        "FastestLapSpeed",
+        "racefans_rating",
+        "air_temp",
+        "humidity",
+    ]:
         if col in latest.columns:
             latest[col] = np.nan
     if "Points" in latest.columns:
@@ -113,6 +121,10 @@ def _prepare_prediction_dataframe(df_hist: pd.DataFrame, year: int, rnd: int) ->
         numeric_features.append("fastest_lap_time")
     if "fastest_lap_speed" in df_all.columns:
         numeric_features.append("fastest_lap_speed")
+    if "air_temp" in df_all.columns:
+        numeric_features.append("air_temp")
+    if "humidity" in df_all.columns:
+        numeric_features.append("humidity")
     for col in ["points_cumsum", "points_ewm", "position_ewm", "fastest_lap_time_ewm", "fastest_lap_speed_ewm"]:
         if col in df_all.columns:
             numeric_features.append(col)


### PR DESCRIPTION
## Summary
- add `extract_weather` to collect temperature and humidity from a `fastf1` session
- store weather info in dataset builder
- treat weather columns as numeric features
- handle the new columns when generating prediction data
- test that weather extraction and feature matrix generation work

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*