### PR TITLE
Compute mean weather from sessions

### DIFF
--- a/f1_predictor/data_loader.py
+++ b/f1_predictor/data_loader.py
@@ -199,11 +199,13 @@ class DataLoader:
         if weather is None or getattr(weather, "empty", True):
             return {"air_temp": None, "humidity": None}
 
-        row = weather.iloc[0]
-        air = pd.to_numeric(row.get("AirTemp"), errors="coerce")
-        hum = pd.to_numeric(row.get("Humidity"), errors="coerce")
+        air_series = pd.to_numeric(weather.get("AirTemp"), errors="coerce")
+        hum_series = pd.to_numeric(weather.get("Humidity"), errors="coerce")
+
+        air_mean = air_series.mean() if air_series is not None else float("nan")
+        hum_mean = hum_series.mean() if hum_series is not None else float("nan")
 
         return {
-            "air_temp": float(air) if not pd.isna(air) else None,
-            "humidity": float(hum) if not pd.isna(hum) else None,
+            "air_temp": float(air_mean) if not pd.isna(air_mean) else None,
+            "humidity": float(hum_mean) if not pd.isna(hum_mean) else None,
         }

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -92,12 +92,14 @@ def test_extract_weather() -> None:
     loader = DataLoader(cache_dir="none", raw_dir="none")
 
     class DummySession:
-        weather_data = pd.DataFrame({"AirTemp": [22.5], "Humidity": [55.0]})
+        weather_data = pd.DataFrame(
+            {"AirTemp": [22.5, 23.5, pd.NA], "Humidity": [55.0, pd.NA, 56.0]}
+        )
 
     weather = loader.extract_weather(DummySession())
 
-    assert weather["air_temp"] == 22.5
-    assert weather["humidity"] == 55.0
+    assert weather["air_temp"] == pytest.approx(23.0)
+    assert weather["humidity"] == pytest.approx(55.5)
 
 
 def test_feature_matrix_with_weather() -> None:


### PR DESCRIPTION
## Summary
- derive average weather metrics from FastF1 sessions
- update `test_extract_weather` to check mean behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*