### PR TITLE
Fix RaceFans rating URL handling

### DIFF
--- a/f1_predictor/data_loader.py
+++ b/f1_predictor/data_loader.py
@@ -110,10 +110,8 @@ class DataLoader:
     def fetch_racefans_rating(self, year: int, round: int) -> Optional[float]:
         """Fetch racefans driver rating for a specific race."""
         urls = [
-            "https://raw.githubusercontent.com/theoehrly/fastf1/main/docs/examples/"
-            "racefans_driver_ratings.csv",
-            "https://raw.githubusercontent.com/theoehrly/fastf1/master/docs/examples/"
-            "racefans_driver_ratings.csv",
+            "https://raw.githubusercontent.com/theoehrly/fastf1/main/docs/examples/racefans_driver_ratings.csv",
+            "https://raw.githubusercontent.com/theoehrly/fastf1/master/docs/examples/racefans_driver_ratings.csv",
         ]
         dest = self.raw_dir / "racefans" / "driver_ratings.csv"
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -76,7 +76,10 @@ def test_tsplit_order() -> None:
 def test_racefans_fallback(tmp_path, monkeypatch) -> None:
     csv_data = "year,round,rating\n2019,1,7.5\n"
 
+    calls = []
+
     def fake_get(self, url: str):
+        calls.append(url)
         if "main" in url:
             raise requests.HTTPError("404")
         return DummyCSVResponse(csv_data)
@@ -86,7 +89,17 @@ def test_racefans_fallback(tmp_path, monkeypatch) -> None:
     loader = DataLoader(cache_dir=tmp_path / "cache", raw_dir=tmp_path / "raw")
     rating = loader.fetch_racefans_rating(2019, 1)
 
+    main_url = (
+        "https://raw.githubusercontent.com/theoehrly/fastf1/main/docs/examples/"
+        "racefans_driver_ratings.csv"
+    )
+    master_url = (
+        "https://raw.githubusercontent.com/theoehrly/fastf1/master/docs/examples/"
+        "racefans_driver_ratings.csv"
+    )
+
     assert rating == 7.5
+    assert calls == [main_url, master_url]
 
 
 def test_extract_weather() -> None:


### PR DESCRIPTION
## Summary
- load RaceFans ratings from explicit URLs
- update fallback test expectations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and numpy)*