### PR TITLE
Improve slug parsing for accented race names

### DIFF
--- a/f1_predictor/predict_next_race.py
+++ b/f1_predictor/predict_next_race.py
@@ -6,6 +6,7 @@ import argparse
 import logging
 from pathlib import Path
 from typing import Optional, Tuple
+import unicodedata
 
 import joblib
 import numpy as np
@@ -59,8 +60,11 @@ def _parse_race_id(race_id: str) -> Tuple[int, int]:
     schedule = loader.fetch_season(year)
     slug = slug.lower().replace(" ", "")
     for _, row in schedule.iterrows():
-        name = str(row.get("raceName") or row.get("RaceName") or "").lower()
-        if slug in name.replace(" ", ""):
+        name = str(row.get("raceName") or row.get("RaceName") or "")
+        norm = unicodedata.normalize("NFKD", name)
+        norm = "".join(c for c in norm if not unicodedata.combining(c))
+        norm = norm.lower()
+        if slug in norm.replace(" ", ""):
             rnd = int(row.get("round") or row.get("Round"))
             return year, rnd
     raise ValueError(f"Race '{race_id}' not found")

--- a/tests/test_predict_next.py
+++ b/tests/test_predict_next.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+from f1_predictor.predict_next_race import _parse_race_id
+from f1_predictor.data_loader import DataLoader
+
+
+def test_parse_slug_with_accents(monkeypatch):
+    def fake_fetch_season(self, year):
+        return pd.DataFrame([
+            {"season": year, "round": 3, "raceName": "Gran Premio de España"}
+        ])
+
+    monkeypatch.setattr(DataLoader, "fetch_season", fake_fetch_season)
+
+    assert _parse_race_id("2025-Spain") == (2025, 3)


### PR DESCRIPTION
## Summary
- handle unicode in race names when parsing user slugs
- add regression test for accented race names

## Testing
- `pytest -q` *(fails: No module named 'pandas')*